### PR TITLE
Query post.excerpt for generating og:description tag for blog posts

### DIFF
--- a/theme/src/templates/post.js
+++ b/theme/src/templates/post.js
@@ -25,6 +25,7 @@ export const query = graphql`
       body
       tags
       draft
+      excerpt
     }
   }
 `


### PR DESCRIPTION
When we share the blog link on a platform, currently the description is not being shown along with the title.
This fixes that issue. Tested.